### PR TITLE
Invoice Description 

### DIFF
--- a/app/admin/invoices.rb
+++ b/app/admin/invoices.rb
@@ -6,6 +6,7 @@ ActiveAdmin.register Invoice do
       f.input :amount, :label => "Amount in $, e.g. 1283.53", :as => :string
       f.input :fee, :label => "Convenience fee as decimial, e.g. 0.01 for 1%", :input_html => {value: STRIPE_FEE / 2}
       f.input :due_date, :label => "Due date", :as => :datepicker, :input_html => {value: (Time.now + PAYMENT_TIME).strftime('%Y-%m-%d')}
+      f.input :description, :label => "Invoice Description", :as => :string
       f.input :stripe_charge_hash, :label => "Stripe charge token (leave blank for unpaid)"
     end
     f.buttons

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,5 +1,5 @@
 class Invoice < ActiveRecord::Base
-  attr_accessible :amount, :client_id, :fee, :paid, :token, :number, :stripe_charge_hash, :due_date, :emailed_on
+  attr_accessible :amount, :client_id, :fee, :paid, :token, :number, :stripe_charge_hash, :due_date, :emailed_on, :description
 
   attr_accessor :stripe_card_token
 

--- a/app/views/client_mailer/new_invoice_email.text.erb
+++ b/app/views/client_mailer/new_invoice_email.text.erb
@@ -4,7 +4,7 @@ Online payment for Invoice #<%= @invoice.number %> is available at this link:
 
 <%= @url %>
 
-This invoice is <%= @due_date_in_words %>.
+This invoice is for <%= @invoice.description %> and is <%= @due_date_in_words %>.
 
 Thanks,
 

--- a/app/views/invoices/paid.html.haml
+++ b/app/views/invoices/paid.html.haml
@@ -1,6 +1,6 @@
 %p Thank you for paying <b>Invoice ##{@invoice.number}</b> in the amount of <b>#{number_to_currency @invoice.total}</b> on #{@invoice.updated_at.strftime('%A, %B %e %Y at %l:%M%P %Z')}.
 
-%p This is your receipt. Please print it for your records.
+%p This is your receipt for #{@invoice.description}. Please print it for your records.
 
 %p Thanks again,
 

--- a/app/views/invoices/show.html.haml
+++ b/app/views/invoices/show.html.haml
@@ -9,6 +9,8 @@
   - elsif @invoice.fee > 0
     This includes a #{(@invoice.fee * 100).round(3)}% convenience fee.
 
+%p This invoice is for #{@invoice.description}
+
 %p Please complete this payment by filling out the form below. We accept any major credit card and use <a href="http://stripe.com" target="_blank">Stripe</a> to safely and securely process your payment.
 
 - if @invoice.due_date_as_date

--- a/db/migrate/20120905172251_add_description_to_invoices.rb
+++ b/db/migrate/20120905172251_add_description_to_invoices.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToInvoices < ActiveRecord::Migration
+  def change
+    change_column :invoices, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(:version => 20120725052918) do
     t.datetime "updated_at",         :null => false
     t.integer  "number"
     t.string   "stripe_charge_hash"
+    t.string   "description"
     t.string   "due_date"
     t.datetime "emailed_on"
   end


### PR DESCRIPTION
Added this so that clients could instantly see what the invoice is for in their records. I made the description a plain text paragraph rather than a line item table to better fit the style of combine.
